### PR TITLE
Handle BadRequest Exception in case 'Chat not found' in send_message

### DIFF
--- a/cs2posts/bot/cs2.py
+++ b/cs2posts/bot/cs2.py
@@ -5,6 +5,7 @@ import logging
 from telegram import Update
 from telegram.constants import ChatType
 from telegram.constants import ParseMode
+from telegram.error import BadRequest
 from telegram.error import Forbidden
 from telegram.ext import Application
 from telegram.ext import CallbackContext
@@ -338,6 +339,13 @@ class CounterStrike2UpdateBot:
 
         try:
             await msg.send(context.bot, chat_id=chat.chat_id)
+        except BadRequest as e:
+            logger.error(f'Bad request for {chat.chat_id=}')
+            if e.message == 'Chat not found':
+                logger.error(
+                    f'Chat not found we delete the chat {chat.chat_id=}')
+                self.chats.remove(chat)
+            logger.error(f"Reason: {e}")
         except Forbidden as e:
             logger.error(
                 f'Bot is blocked by user we delete the chat {chat.chat_id=}')

--- a/tests/bot/test_cs2bot.py
+++ b/tests/bot/test_cs2bot.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 from telegram import Update
 from telegram.constants import ChatType
+from telegram.error import BadRequest
 from telegram.error import Forbidden
 
 from cs2posts.bot.chats import Chat
@@ -494,6 +495,36 @@ async def test_cs2_bot_send_message(bot):
     mocked_msg.send.assert_called_once_with(
         mocked_context.bot, chat_id=chat.chat_id)
     mocked_msg.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cs2_bot_send_message_raises_bad_request_chat_not_found(bot):
+    mocked_context = AsyncMock()
+    mocked_context.bot = AsyncMock()
+    mocked_msg = AsyncMock()
+    mocked_msg.send = AsyncMock()
+    mocked_msg.send.side_effect = BadRequest("Chat not found")
+    chat = Chat(42)
+
+    await bot.send_message(mocked_context, mocked_msg, chat)
+    mocked_msg.send.assert_called_once_with(
+        mocked_context.bot, chat_id=chat.chat_id)
+    bot.chats.remove.assert_called_once_with(chat)
+
+
+@pytest.mark.asyncio
+async def test_cs2_bot_send_message_raises_bad_request(bot):
+    mocked_context = AsyncMock()
+    mocked_context.bot = AsyncMock()
+    mocked_msg = AsyncMock()
+    mocked_msg.send = AsyncMock()
+    mocked_msg.send.side_effect = BadRequest("something")
+    chat = Chat(42)
+
+    await bot.send_message(mocked_context, mocked_msg, chat)
+    mocked_msg.send.assert_called_once_with(
+        mocked_context.bot, chat_id=chat.chat_id)
+    bot.chats.remove.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
As of now we only handle the case if the bot is blocked but not if the group chat actually exists.
In case the chat has been deleted and the `chat_id` is invalid a `BadRequest` exception 
with 'Chat not found' is raised.