### PR TITLE
Fix heading from update post 2024-10-02

### DIFF
--- a/cs2posts/parser/steam_update_heading.py
+++ b/cs2posts/parser/steam_update_heading.py
@@ -7,7 +7,7 @@ from cs2posts.parser.parser import Parser
 
 class SteamUpdateHeadingParser(Parser):
 
-    HEADING_REGEX = r'\[([A-Z0-9\s]+)\]'
+    HEADING_REGEX = r'\[([A-Z0-9&\s]+)\]'
 
     def __init__(self, text: str):
         super().__init__(text)

--- a/tests/parser/test_steam_update_heading.py
+++ b/tests/parser/test_steam_update_heading.py
@@ -29,3 +29,8 @@ def test_steam_update_heading_parser_no_heading(steam_parser):
     expected = "This is just some text with [CT] in the middle."
     steam_parser.text = expected
     assert steam_parser.parse() == expected
+
+
+def test_steam_update_heading_parser_multiple(steam_parser):
+    steam_parser.text = "\n[INVENTORY & ITEMS]\n"
+    assert steam_parser.parse() == "\n<b>[INVENTORY & ITEMS]</b>\n"


### PR DESCRIPTION
Right now the following heading is not
detected as heading:

"[FOO & BAR]"

now "&" is also considered.