### PR TITLE
Fix heading from update post 2024-08-19

### DIFF
--- a/cs2posts/parser/steam_update_heading.py
+++ b/cs2posts/parser/steam_update_heading.py
@@ -7,7 +7,7 @@ from cs2posts.parser.parser import Parser
 
 class SteamUpdateHeadingParser(Parser):
 
-    HEADING_REGEX = r'\[([A-Z0-9&\s]+)\]'
+    HEADING_REGEX = r'\[([a-zA-Z0-9&\s]+)\]'
 
     def __init__(self, text: str):
         super().__init__(text)

--- a/tests/parser/test_steam_update_heading.py
+++ b/tests/parser/test_steam_update_heading.py
@@ -34,3 +34,8 @@ def test_steam_update_heading_parser_no_heading(steam_parser):
 def test_steam_update_heading_parser_multiple(steam_parser):
     steam_parser.text = "\n[INVENTORY & ITEMS]\n"
     assert steam_parser.parse() == "\n<b>[INVENTORY & ITEMS]</b>\n"
+
+
+def test_steam_update_heading_parser_vacnet(steam_parser):
+    steam_parser.text = "\n[ VacNet ]\n"
+    assert steam_parser.parse() == "\n<b>[ VacNet ]</b>\n"


### PR DESCRIPTION
"[ VacNet ]" was not detected.
Small letters where not considered till now.